### PR TITLE
fix: Add Spanish translations

### DIFF
--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -1,0 +1,21 @@
+[{
+  "i18n": "es",
+  "ns": "reaction-simple-inventory",
+  "translation": {
+    "reaction-simple-inventory": {
+      "productVariant": {
+        "allowBackorder": "Permitir pedido pendiente",
+        "inventoryDisabled": "El seguimiento de inventario está deshabilitado",
+        "inventoryHeading": "Inventario",
+        "inventoryInStock": "Cantidad",
+        "inventoryInStockHelpText": "{{inventoryInStock}} en stock - {{inventoryReserved}} en reserva = {{inventoryAvailableToSell}} disponible",
+        "inventoryMessage": "Si la gestión de inventario está deshabilitada para una variante, los compradores siempre pueden pedir cualquier cantidad. Si la gestión de inventario está habilitada, los compradores solo pueden realizar pedidos hasta la cantidad disponible, a menos que se habilite los pedidos pendientes. Todos los cambios de esta tarjeta tienen efecto inmediato. La publicación no es necesaria.",
+        "isInventoryManagementEnabled": "Gestionar Inventario",
+        "lowInventoryWarningThreshold": "Advertir con",
+        "lowInventoryWarningThresholdLabel": "Advierta a los clientes que el producto estará cerca de agotarse cuando la cantidad disponible alcance este umbral",
+        "noInventoryTracking": "El inventario se rastrea solo para las variantes que pueden venderse. Seleccione una opción para administrar el inventario.",
+        "recalculateReservedInventory": "Recalculate reserved quantity"
+      }
+    }
+  }
+}]

--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -1,4 +1,5 @@
 import en from "./en.json";
+import es from "./es.json";
 
 //
 // we want all the files in individual
@@ -6,5 +7,8 @@ import en from "./en.json";
 // automated translation software
 //
 export default {
-  translations: [...en]
+  translations: [
+    ...en,
+    ...es
+  ]
 };


### PR DESCRIPTION
Signed-off-by: Matias Zuniga <matias.nicolas.zc@gmail.com>

Impact: **minor**
Type: **bugfix**

## Issue
Spanish translations are not present in the admin panel, when managing the inventory of a product.

## Solution
Add the Spanish translations to the inventory-simple plugin. I see that this repo has only english translations, it is desirable to have other languages?

## Testing
Link this PR into the Reaction API
Start Reaction
Go to the admin panel with a browser that has Spanish as primary language
Add a product, change inventory, look at the Spanish translations