### PR TITLE
fix: Add missing Spanish translation

### DIFF
--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -14,7 +14,7 @@
         "lowInventoryWarningThreshold": "Advertir con",
         "lowInventoryWarningThresholdLabel": "Advierta a los clientes que el producto estará cerca de agotarse cuando la cantidad disponible alcance este umbral",
         "noInventoryTracking": "El inventario se rastrea solo para las variantes que pueden venderse. Seleccione una opción para administrar el inventario.",
-        "recalculateReservedInventory": "Recalculate reserved quantity"
+        "recalculateReservedInventory": "Recalcular cantidad reservada"
       }
     }
   }


### PR DESCRIPTION
Signed-off-by: Matias Zuniga <matias.nicolas.zc@gmail.com>

Impact: **minor**
Type: **bugfix**

## Issue
The button to recalculate reserved quantity (in the inventory block of the variant editor) was in English, even if the admin was in Spanish

My translations merged from #6 had the original recalculateReservedInventory string, instead of the translated one.

## Solution
Replace recalculateReservedInventory with the Spanish translation

## Breaking changes
None